### PR TITLE
Fix generated pack loading on windows

### DIFF
--- a/common/src/main/java/com/minenash/embedded_assets/server/PackCreator.java
+++ b/common/src/main/java/com/minenash/embedded_assets/server/PackCreator.java
@@ -66,7 +66,7 @@ public class PackCreator {
 
         try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("resources.zip"))) {
             for (var entry : workingData.entrySet()) {
-                ZipEntry e = new ZipEntry(entry.getKey());
+                ZipEntry e = new ZipEntry(entry.getKey().replace("\\", "/"));
                 e.setLastModifiedTime(lastModified.getOrDefault(entry.getKey(), FileTime.from(Instant.now())));
                 zos.putNextEntry(e);
                 zos.write(entry.getValue());


### PR DESCRIPTION
The minecraft client on windows is particular about the slash used in zip files, and will refuse to load the pack (and get stuck in a never ending loop) if it uses the incorrect slash. 
This can be fixed by replaceing all the incorrect slashes with the correct one when constructing the zip file.

This can also be seen in a similar project here: https://github.com/Patbox/polymer/pull/9

 